### PR TITLE
Update bcrypt import

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"strconv"
 
-	"code.google.com/p/go.crypto/bcrypt"
+	"golang.org/x/crypto/bcrypt"
 )
 
 const (


### PR DESCRIPTION
`code.google.com` is gone.
